### PR TITLE
Change Primary URL of the Sample Locator

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -67,4 +67,25 @@ CREATE USER auth WITH ENCRYPTED PASSWORD '...';
 GRANT ALL PRIVILEGES ON DATABASE auth TO auth;
 ```
 
+## Create New Let's Encrypt Certificate
+
+Check chat the certificate isn't already known:
+
+```bash
+docker run --rm -v /etc/nginx/ssl:/etc/letsencrypt certbot/certbot:v0.36.0 certificates
+```
+
+First do a dry run:
+
+```bash
+docker run --rm \
+  -v /etc/nginx/ssl:/etc/letsencrypt \
+  -v acme-challenge:/certbot \
+  certbot/certbot:v0.36.0 \
+  certonly --dry-run --agree-tos --webroot --webroot-path /certbot \
+  -d <domain>
+```
+
+Than do the same removing `--dry-run`
+
 [1]: <https://github.com/samply/open-telekom-cloud/tree/master/modules/postgres>

--- a/modules/server/certbot/certbot.service.tmpl
+++ b/modules/server/certbot/certbot.service.tmpl
@@ -1,28 +1,20 @@
 [Unit]
-Description=Certbot renewing ssl https certificates
-After=docker.service,nginx.service,init-network.service
-Requires=docker.service,nginx.service,init-network.service
+Description=Certbot renewing HTTPS certificates
+After=docker.service,nginx.service
+Requires=docker.service,nginx.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStartPre=-/usr/bin/docker volume create acme-challenge
 ExecStartPre=/usr/bin/docker pull certbot/certbot:${version}
 ExecStart=/usr/bin/docker run \
     --name=certbot \
     --rm \
-    --network=gba \
     -v /etc/nginx/ssl:/etc/letsencrypt \
     -v acme-challenge:/certbot \
-certbot/certbot:${version} certonly \
-    --noninteractive \
-    --agree-tos \
-    --email ${email} \
-    --webroot \
-    --webroot-path /certbot \
-    -d ${domains}
-
-ExecStartPost=/usr/bin/docker container exec nginx nginx -s reload
+    certbot/certbot:${version} renew \
+    --email ${email}
+ExecStartPost=/usr/bin/docker exec nginx nginx -s reload
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/server/certbot/main.tf
+++ b/modules/server/certbot/main.tf
@@ -3,7 +3,6 @@ data "template_file" "certbot_service" {
   vars = {
     version = var.certbot_version
     email   = "notify@germanbiobanknode.de"
-    domains = join(" -d ", var.certbot_domains)
   }
 }
 

--- a/modules/server/certbot/variables.tf
+++ b/modules/server/certbot/variables.tf
@@ -1,7 +1,3 @@
 variable "certbot_version" {
   type = "string"
 }
-
-variable "certbot_domains" {
-  type = "list"
-}

--- a/modules/server/init-network/init-network.service.tmpl
+++ b/modules/server/init-network/init-network.service.tmpl
@@ -5,7 +5,7 @@ Requires=docker.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/docker network create gba
+ExecStart=-/usr/bin/docker network create gba
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -18,11 +18,6 @@ module "nginx" {
 module "certbot" {
   source          = "./certbot"
   certbot_version = "v0.36.0"
-  certbot_domains = [
-    "search.germanbiobanknode.de",
-    "auth.germanbiobanknode.de",
-    "mdr.germanbiobanknode.de"
-  ]
 }
 
 module "searchbroker" {
@@ -114,7 +109,8 @@ data "ignition_config" "server" {
   ]
   directories = [
     data.ignition_directory.secrets_mount_point_folder.id,
-    data.ignition_directory.ssl_mount_point_folder.id
+    data.ignition_directory.ssl_mount_point_folder.id,
+    module.nginx.etc_nginx_dir
   ]
   files       = [
     data.ignition_file.hostname.id,

--- a/modules/server/nginx/acme-challenge.global.tmpl
+++ b/modules/server/nginx/acme-challenge.global.tmpl
@@ -1,5 +1,5 @@
 location  /.well-known/acme-challenge {
-        root /certbot;
-        autoindex on;
-        allow all;
+    root /certbot/.well-known/acme-challenge;
+    autoindex on;
+    allow all;
 }

--- a/modules/server/nginx/main.tf
+++ b/modules/server/nginx/main.tf
@@ -1,3 +1,9 @@
+data "ignition_directory" "etc_nginx" {
+  filesystem = "root"
+  path       = "/etc/nginx"
+  mode       = "0755"
+}
+
 data "template_file" "acme-challenge_global" {
   template = file("${path.module}/acme-challenge.global.tmpl")
 }

--- a/modules/server/nginx/nginx.service.tmpl
+++ b/modules/server/nginx/nginx.service.tmpl
@@ -15,8 +15,7 @@ ExecStart=/usr/bin/docker run \
     -v /etc/nginx/ssl:/etc/nginx/ssl:ro \
     -v acme-challenge:/certbot/.well-known/acme-challenge \
     -p 443:443 -p 80:80 \
-nginx:${version}
-
+    nginx:${version}
 ExecStop=/usr/bin/docker stop nginx
 
 [Install]

--- a/modules/server/nginx/outputs.tf
+++ b/modules/server/nginx/outputs.tf
@@ -1,3 +1,7 @@
+output "etc_nginx_dir" {
+  value = data.ignition_directory.etc_nginx.id
+}
+
 output "acme-challenge_global_file" {
   value = data.ignition_file.acme-challenge_global.id
 }

--- a/modules/server/nginx/searchbroker.conf.tmpl
+++ b/modules/server/nginx/searchbroker.conf.tmpl
@@ -4,7 +4,7 @@ server {
     include /etc/nginx/conf.d/acme-challenge.global;
 
     location / {
-        rewrite ^ https://$server_name$request_uri? permanent;
+        rewrite ^ https://samplelocator.bbmri.de$request_uri? permanent;
     }
 
     location /broker {
@@ -21,6 +21,36 @@ server {
 
     ssl_certificate     /etc/nginx/ssl/live/search.germanbiobanknode.de/fullchain.pem;
     ssl_certificate_key /etc/nginx/ssl/live/search.germanbiobanknode.de/privkey.pem;
+
+    location / {
+        rewrite ^ https://samplelocator.bbmri.de$request_uri? permanent;
+    }
+
+    location /broker {
+        proxy_pass http://searchbroker:8080/broker;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+server {
+    listen 80;
+    server_name samplelocator.bbmri.de;
+    include /etc/nginx/conf.d/acme-challenge.global;
+
+    location / {
+        rewrite ^ https://$server_name$request_uri? permanent;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name samplelocator.bbmri.de;
+
+    ssl_certificate     /etc/nginx/ssl/live/samplelocator.bbmri.de/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/samplelocator.bbmri.de/privkey.pem;
 
     location / {
         proxy_pass http://searchbroker-ui:8080/;


### PR DESCRIPTION
I've no redirect from http(s)://search.germanbiobanknode.de/broker to
https://samplelocator.bbmri.de/broker, because some sites have special firewall
rules to include only search.germanbiobanknode.de.