### PR TITLE
Fix certbot service only started once by timer

### DIFF
--- a/modules/server/certbot/certbot.service.tmpl
+++ b/modules/server/certbot/certbot.service.tmpl
@@ -4,8 +4,6 @@ After=docker.service,nginx.service
 Requires=docker.service,nginx.service
 
 [Service]
-Type=oneshot
-RemainAfterExit=true
 ExecStartPre=/usr/bin/docker pull certbot/certbot:${version}
 ExecStart=/usr/bin/docker run \
     --name=certbot \


### PR DESCRIPTION
Certbot could only be started once after system start.
The option "RemainAfterExit" forced the service to always stay in active state, that means it's timer could not start certbot again, which leads to invalid ssl certificates.