### PR TITLE
Updated MDR images to fix log4j problem

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -33,8 +33,8 @@ module "icd_dictionary" {
 
 module "mdr" {
   source         = "./mdr"
-  mdr_version    = "4.0.4-SNAPSHOT"
-  mdr-ui_version = "2.0.6-SNAPSHOT"
+  mdr_version    = "release-gba-mdr"
+  mdr-ui_version = "master"
 }
 
 data "ignition_disk" "data" {

--- a/modules/server/mdr/mdr-ui.service.tmpl
+++ b/modules/server/mdr/mdr-ui.service.tmpl
@@ -8,7 +8,7 @@ Restart=always
 EnvironmentFile=/mnt/secrets/mdr
 ExecStartPre=-/usr/bin/docker kill mdr-ui
 ExecStartPre=-/usr/bin/docker rm mdr-ui
-ExecStartPre=/usr/bin/docker pull martinbreu/mdr-ui:${version}
+ExecStartPre=/usr/bin/docker pull docker.verbis.dkfz.de/ccp/mdr:${version}
 ExecStart=/usr/bin/docker run \
   --name=mdr-ui \
   --network=gba \
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/docker run \
   -e AUTH_CLIENT_ID='$${AUTH_CLIENT_ID}' \
   -e AUTH_CLIENT_SECRET='$${AUTH_CLIENT_SECRET}' \
   -e CATALINA_OPTS='"-Xmx2g"' \
-  martinbreu/mdr-ui:${version}
+  docker.verbis.dkfz.de/ccp/mdr:${version}
 ExecStop=/usr/bin/docker stop mdr-ui
 
 [Install]

--- a/modules/server/mdr/mdr.service.tmpl
+++ b/modules/server/mdr/mdr.service.tmpl
@@ -8,22 +8,22 @@ Restart=always
 EnvironmentFile=/mnt/secrets/mdr
 ExecStartPre=-/usr/bin/docker kill mdr
 ExecStartPre=-/usr/bin/docker rm mdr
-ExecStartPre=/usr/bin/docker pull martinbreu/mdr:${version}
+ExecStartPre=/usr/bin/docker pull docker.verbis.dkfz.de/ccp/mdr-rest:${version}
 ExecStart=/usr/bin/docker run \
   --name=mdr \
   --network=gba \
   -e TOMCAT_USERNAME='admin' \
   -e TOMCAT_PASSWORD='$${TOMCAT_PASS}' \
-  -e POSTGRES_HOST='postgres.openstacklocal' \
-  -e POSTGRES_DB='mdr_db' \
-  -e POSTGRES_USER='mdr' \
-  -e POSTGRES_PASS='$${POSTGRES_PASS}' \
+  -e DB_HOST='postgres.openstacklocal' \
+  -e DB_NAME='mdr_db' \
+  -e DB_USER='mdr' \
+  -e DB_PASSWORD='$${POSTGRES_PASS}' \
   -e AUTH_HOST='${auth_host}' \
-  -e AUTH_PUBLIC_KEY='$${AUTH_PUBLIC_KEY}' \
+  -e AUTH_PUBKEY='$${AUTH_PUBLIC_KEY}' \
   -e AUTH_CLIENT_ID='$${AUTH_CLIENT_ID}' \
   -e AUTH_CLIENT_SECRET='$${AUTH_CLIENT_SECRET}' \
   -e CATALINA_OPTS='"-Xmx2g"' \
-  martinbreu/mdr:${version}
+  docker.verbis.dkfz.de/ccp/mdr-rest:${version}
 ExecStop=/usr/bin/docker stop mdr
 
 [Install]


### PR DESCRIPTION
Note that image names have changed since martinbreu.

DB schema should not have changed, so existing MDRs can simply be
restarted with the new images, but database backup is advised just in
case.

Also, I have used absolute versions. Please advise if more flexible
versioning is required.